### PR TITLE
Add YAML processor support for CloudFormation templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 .idea/
 .vscode/
+
+# Sample template files
+samples/

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require github.com/spf13/cobra v1.9.1
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/ksysoev/cfn-proc
 
 go 1.24.4
 
-require github.com/spf13/cobra v1.9.1
+require (
+	github.com/spf13/cobra v1.9.1
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -7,4 +7,5 @@ github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wx
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/cmd/file.go
+++ b/pkg/cmd/file.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ksysoev/cfn-proc/pkg/file"
+)
+
+func runProcessor(_ context.Context, args cmdArgs, sargs []string) error {
+	if len(sargs) != 1 {
+		return fmt.Errorf("expected one input file")
+	}
+
+	processor, err := file.New(sargs[0], args.Out)
+	if err != nil {
+		return err
+	}
+
+	if err := processor.Process(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/file.go
+++ b/pkg/cmd/file.go
@@ -7,6 +7,9 @@ import (
 	"github.com/ksysoev/cfn-proc/pkg/file"
 )
 
+// runProcessor processes the input file specified in sargs and writes the transformed output to the file specified in args.Out.
+// It validates that exactly one input file is provided in sargs and fails if input and output paths are the same.
+// Returns an error if the input file cannot be opened, decoded, or if writing the output file fails.
 func runProcessor(_ context.Context, args cmdArgs, sargs []string) error {
 	if len(sargs) != 1 {
 		return fmt.Errorf("expected one input file")

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -15,8 +13,12 @@ type cmdArgs struct {
 	Out     string
 }
 
+// InitCommand initializes and returns a cobra.Command for CloudFormation pre-processing tasks.
+// It configures the command with build information and sets up necessary flags.
+// Accepts build that contains application version information.
+// Returns a fully configured cobra.Command instance.
 func InitCommand(build BuildInfo) cobra.Command {
-	args := &cmdArgs{
+	args := cmdArgs{
 		Version: build.Version,
 	}
 
@@ -25,7 +27,7 @@ func InitCommand(build BuildInfo) cobra.Command {
 		Short: "CloudFormation pre-processor",
 		Long:  "cfn-proc is a tool for processing CloudFormation templates, allowing for custom pre-processing steps before deployment.",
 		RunE: func(cmd *cobra.Command, sargs []string) error {
-			return runProcessor(cmd, args, sargs)
+			return runProcessor(cmd.Context(), args, sargs)
 		},
 	}
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -12,21 +12,24 @@ type BuildInfo struct {
 
 type cmdArgs struct {
 	Version string
+	Out     string
 }
 
 func InitCommand(build BuildInfo) cobra.Command {
-	_ = &cmdArgs{
+	args := &cmdArgs{
 		Version: build.Version,
 	}
 
 	cmd := cobra.Command{
 		Use:   "cfn-proc",
-		Short: "",
-		Long:  "",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return fmt.Errorf("not implemented")
+		Short: "CloudFormation pre-processor",
+		Long:  "cfn-proc is a tool for processing CloudFormation templates, allowing for custom pre-processing steps before deployment.",
+		RunE: func(cmd *cobra.Command, sargs []string) error {
+			return runProcessor(cmd, args, sargs)
 		},
 	}
+
+	cmd.Flags().StringVarP(&args.Out, "out", "o", "output.yml", "Output file")
 
 	return cmd
 }

--- a/pkg/file/proc.go
+++ b/pkg/file/proc.go
@@ -26,7 +26,7 @@ func New(inpath, outpath string) (*Processor, error) {
 // Process is a placeholder for the actual processing logic.
 // It currently returns an error indicating that the method is not implemented.
 func (p *Processor) Process() error {
-	inFile, err := os.OpenFile(p.inpath, os.O_RDONLY, 0644)
+	inFile, err := os.OpenFile(p.inpath, os.O_RDONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to open input file %s: %w", p.inpath, err)
 	}
@@ -39,7 +39,7 @@ func (p *Processor) Process() error {
 		return fmt.Errorf("failed to decode input file %s: %w", p.inpath, err)
 	}
 
-	outFile, err := os.OpenFile(p.outpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	outFile, err := os.OpenFile(p.outpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to open output file %s: %w", p.outpath, err)
 	}

--- a/pkg/file/proc.go
+++ b/pkg/file/proc.go
@@ -12,6 +12,9 @@ type Processor struct {
 	outpath string
 }
 
+// New creates and initializes a new Processor for handling input and output file paths.
+// It ensures that the input and output paths are not the same.
+// Returns a Processor to manage file transformations and an error if the paths are identical.
 func New(inpath, outpath string) (*Processor, error) {
 	if inpath == outpath {
 		return nil, fmt.Errorf("input and output paths must be different")
@@ -23,31 +26,30 @@ func New(inpath, outpath string) (*Processor, error) {
 	}, nil
 }
 
-// Process is a placeholder for the actual processing logic.
-// It currently returns an error indicating that the method is not implemented.
+// Process reads a YAML file, deserializes its contents, and writes them in YAML format to an output file.
+// It manages input and output file paths defined in the Processor, ensuring proper encoding and error handling.
+// Returns an error if file operations fail, YAML parsing is unsuccessful, or encoding to the output file encounters an issue.
 func (p *Processor) Process() error {
-	inFile, err := os.OpenFile(p.inpath, os.O_RDONLY, 0o644)
+	data, err := os.ReadFile(p.inpath)
 	if err != nil {
-		return fmt.Errorf("failed to open input file %s: %w", p.inpath, err)
+		return fmt.Errorf("failed to read input file %s: %w", p.inpath, err)
 	}
 
-	defer inFile.Close()
-
-	var data any
-
-	if err := yaml.NewDecoder(inFile).Decode(&data); err != nil {
-		return fmt.Errorf("failed to decode input file %s: %w", p.inpath, err)
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return fmt.Errorf("failed to parse YAML from input file %s: %w", p.inpath, err)
 	}
 
 	outFile, err := os.OpenFile(p.outpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to open output file %s: %w", p.outpath, err)
 	}
-
 	defer outFile.Close()
 
-	if err := yaml.NewEncoder(outFile).Encode(data); err != nil {
-		return fmt.Errorf("failed to encode output file %s: %w", p.outpath, err)
+	encoder := yaml.NewEncoder(outFile)
+
+	if err := encoder.Encode(&node); err != nil {
+		return fmt.Errorf("failed to encode YAML to output file %s: %w", p.outpath, err)
 	}
 
 	return nil

--- a/pkg/file/proc.go
+++ b/pkg/file/proc.go
@@ -1,0 +1,54 @@
+package file
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Processor struct {
+	inpath  string
+	outpath string
+}
+
+func New(inpath, outpath string) (*Processor, error) {
+	if inpath == outpath {
+		return nil, fmt.Errorf("input and output paths must be different")
+	}
+
+	return &Processor{
+		inpath:  inpath,
+		outpath: outpath,
+	}, nil
+}
+
+// Process is a placeholder for the actual processing logic.
+// It currently returns an error indicating that the method is not implemented.
+func (p *Processor) Process() error {
+	inFile, err := os.OpenFile(p.inpath, os.O_RDONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open input file %s: %w", p.inpath, err)
+	}
+
+	defer inFile.Close()
+
+	var data any
+
+	if err := yaml.NewDecoder(inFile).Decode(&data); err != nil {
+		return fmt.Errorf("failed to decode input file %s: %w", p.inpath, err)
+	}
+
+	outFile, err := os.OpenFile(p.outpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open output file %s: %w", p.outpath, err)
+	}
+
+	defer outFile.Close()
+
+	if err := yaml.NewEncoder(outFile).Encode(data); err != nil {
+		return fmt.Errorf("failed to encode output file %s: %w", p.outpath, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Description

This pull request introduces a new `Processor` to handle YAML input and output specifically for processing CloudFormation templates. The implementation validates YAML content and supports extended functionality in the `init` command by adding a `--out` flag to specify the output file location. Additionally, the `gopkg.in/yaml.v3` dependency has been added to facilitate YAML processing.